### PR TITLE
Env,Python: Make python scripts executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ install:
 	pip install -r requirements.txt
 
 preprocess:
-	python prepro_tinyshakespeare.py
-	python train_gpt2.py
+	./prepro_tinyshakespeare.py
+	./train_gpt2.py
 
 train:	llm-rs/src/main.rs
 	cd llm-rs && cargo build --release && cp target/release/llm-rs ../train

--- a/prepro_tinyshakespeare.py
+++ b/prepro_tinyshakespeare.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 """
 Downloads and tokenizes the TinyShakespeare dataset.
 - The download is from Github.

--- a/prepro_tinystories.py
+++ b/prepro_tinystories.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 """
 Downloads and tokenizes the TinyStories dataset.
 - The download is from HuggingFace datasets.

--- a/train_gpt2.py
+++ b/train_gpt2.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 """
 Reference code for GPT-2 training and inference.
 Will save the model weights into files, to be read from C as initialization.


### PR DESCRIPTION
With this you can simply run `./python_script.py` instead of `python python_script.py`